### PR TITLE
Closes issue #1

### DIFF
--- a/bin/zapper
+++ b/bin/zapper
@@ -36,6 +36,8 @@ from __future__ import absolute_import
 import sys
 
 from zapper.cli import main
+from zapper.zapper import ZapperError
+from zapper.utils import print_err
 
 
 if __name__ == '__main__':
@@ -43,8 +45,11 @@ if __name__ == '__main__':
     try:
         sys.exit(main())
     except KeyboardInterrupt:
-        print('Stopping!')
-    except (IOError, OSError) as e:
-        print('Error: {0}'.format(e))
+        print_err('Stopping!')
+        sys.exit(1)
+    except (IOError, OSError, ZapperError) as e:
+        print_err('Error: {0}'.format(e))
+        sys.exit(1)
     except ValueError as e:
-        print('Config Error: {0}'.format(e))
+        print_err('Config Error: {0}'.format(e))
+        sys.exit(1)

--- a/zapper/cli.py
+++ b/zapper/cli.py
@@ -37,7 +37,7 @@ import argparse
 
 import yaml
 
-from zapper.zapper import Zapper  # Now THAT'S an import
+from zapper.zapper import Zapper
 from zapper.utils import file_exists
 
 
@@ -232,7 +232,7 @@ def _zap(src, dest, opts, verbose):
                     ignore=opts.get('ignore'),
                     clean_pyc=opts.get('clean_pyc'),
                     debug=verbose)
-    zapper.build()
+    return zapper
 
 
 def main():
@@ -260,7 +260,9 @@ def main():
     if isinstance(zapper_opts, list):
         for instance_opts in zapper_opts:
             instance_opts.update(cli_opts)
-            _zap(args.src_path, args.dest_path, instance_opts, args.verbose)
+            zapper = _zap(args.src_path, args.dest_path, instance_opts, args.verbose)
     else:
         zapper_opts.update(cli_opts)
-        _zap(args.src_path, args.dest_path, zapper_opts, args.verbose)
+        zapper = _zap(args.src_path, args.dest_path, zapper_opts, args.verbose)
+
+    zapper.build()

--- a/zapper/utils.py
+++ b/zapper/utils.py
@@ -24,9 +24,10 @@
 """
 utils.py -- Conveincence functions for zapper.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
+import sys
 import subprocess
 
 from jinja2 import Environment, PackageLoader, TemplateNotFound, UndefinedError
@@ -123,21 +124,6 @@ def render_template(template_name, **kwargs):
     return template_data
 
 
-def shell_out(cmd):
-    """
-    Run a shell command.
-
-    Args:
-        cmd (list):         A pre-tokenized command to run.
-    """
-
-    pid = subprocess.Popen(cmd,
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
-
-    return pid.communicate()
-
-
 def file_executable(fpath):
     """
     Check if a provided file path exists and is executable.
@@ -176,3 +162,13 @@ def which(program):
                 return exe_file
 
     return None
+
+
+def print_err(*args, **kwargs):
+    """
+    Print to stderr
+    Args:
+        *args to pass down to print function.
+        *kwargs to pass down to print function.
+    """
+    print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
Zapper now properly fails out when pip returns non-zero while
installing dependencies.
